### PR TITLE
#1 [update] Aを1, 11としてスコア計算できるよう修正（サブスコアを用意）

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,6 +68,9 @@ class Game:
         self.dealer.draw_card(deck, 2)
         # player初期スコア計算
         self.player.calc_current_score(self.player.hands)
+        player_sub_score = ""
+        if self.player.draw_A_flg is True:
+            player_sub_score = f", {self.player.card_current_score_sub}"
 
         # 初期ドロー時のスコア表示（dealer側の1枚は伏せる）
         print("\n--Game Start--\n")
@@ -76,7 +79,7 @@ class Game:
 dealer's hands : [{self.dealer.hands[0]}, *-*]
 player's hands : {self.player.hands}
 
-players's total_score : {self.player.card_current_score}\
+players's total_score : {self.player.card_current_score}{player_sub_score}\
         """
         print(f"{first_msg}")
 

--- a/role.py
+++ b/role.py
@@ -7,6 +7,8 @@ class Player:
         self.win_count = 0
         self.hands = []
         self.card_current_score = 0
+        self.card_current_score_sub = 0
+        self.draw_A_flg = False
 
     def keep_drawing_card(self, deck):
         """
@@ -25,15 +27,26 @@ class Player:
             if hit_or_stand_res == "1":
                 # hit の場合は1枚ドロー
                 self.draw_card(deck)
-                print(f"\ndealer's hands : {self.hands[0]} , *-*")
-                print(f"players's total_score : {self.card_current_score}")
                 print(f"player draw card is : {self.hands[-1]}")
                 self.calc_current_score(self.hands)
-                print(f"players's total_score : {self.card_current_score}")
+                sub_score = ""
+                if self.draw_A_flg is True:
+                    sub_score = \
+                        f", {self.card_current_score_sub}"
+                print(
+                    f"players's total_score : \
+{self.card_current_score}{sub_score}")
 
                 # バーストでplayerターン強制終了
-                if self.is_score_burst(int(self.card_current_score)):
+                if self.is_score_burst(int(self.card_current_score)) and \
+                    self.is_score_burst(
+                        int(self.card_current_score_sub)):
                     print("player burst!!!")
+                    hit_flg = False
+
+                if self.card_current_score == 21 or \
+                        self.card_current_score_sub == 21:
+                    # 21になった時点で強制終了
                     hit_flg = False
 
             elif hit_or_stand_res == "2":
@@ -110,9 +123,16 @@ class Player:
             現在のスコア
         """
         self.card_current_score = 0
+        self.card_current_score_sub = 0
         for card in current_hands:
             card_value = self.rank_to_value(str(card))
+            # Aの時も考慮
             self.card_current_score += card_value
+            self.card_current_score_sub += card_value
+            if card_value == 1:
+                self.draw_A_flg = True
+                self.card_current_score_sub += 11
+                continue
 
     def is_score_burst(self, total_score):
         """
@@ -140,10 +160,18 @@ class Dealer(Player):
         super().__init__()
 
     def keep_drawing_card(self, deck):
-        while self.card_current_score < 17:
+        while self.card_current_score < 17 and \
+                self.card_current_score_sub < 17:
             self.draw_card(deck)
             print(f"dealer draw card is : {self.hands[-1]}")
             self.calc_current_score(self.hands)
-            print(f"dealer's total_score : {self.card_current_score}")
-            if self.is_score_burst(self.card_current_score):
+            sub_score = ""
+            if self.draw_A_flg is True:
+                sub_score = \
+                    f", {self.card_current_score_sub}"
+            print(
+                f"dealer's total_score : {self.card_current_score}{sub_score}")
+            if self.is_score_burst(self.card_current_score) and \
+                    self.is_score_burst(
+                    int(self.card_current_score_sub)):
                 print("dealer burst!!!")


### PR DESCRIPTION
# 概要
#1 の対応  
player、dealer（playerオーバーライド）共に対応できるようplayerクラスのメソッド内で対応  
表示側はplayer、dealerそれぞれの`keep_drawing_card`

# 実装の流れ
1. もう一つスコアを用意（サブスコア）
2. Aがきても来なくても通常のカードはメインスコア、サブスコアに加算
3. AがきたらフラグをTrueにし、メインスコアは+1、サブスコアは+11
4. AのフラグがTrueの場合のみコンソールに表示